### PR TITLE
Update _index.pt.md

### DIFF
--- a/workshop/content/labs/basics/api-gateway/_index.pt.md
+++ b/workshop/content/labs/basics/api-gateway/_index.pt.md
@@ -28,7 +28,7 @@ Esse exercício irá mostrar os passos para você configurar rapidamente suas ap
 **Tempo de Execução Estimado:** 40 minutos
 
 **Custo Aproximado**: 3 USD
-
+In you diagram and in the CFN template both vpc have CIDR 10.0.0.0/16. With this configuration VPC peering will not work as overlapping VPC CIDR ranges are not allowed. 
 ![Arquitetura API Gateway](/images/apigw-lab-architecture.png)
 
 ### Execução


### PR DESCRIPTION
In you diagram and in the CFN template both vpc have CIDR 10.0.0.0/16. With this configuration VPC peering will not work as overlapping VPC CIDR ranges are not allowed.

Also in general could you explain the architecture used? For instance it is not clear to me why you use a load balancer in front of a API GW why not just point point R53 to a Regional API GW endpoint ect?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
