### PR TITLE
fix multiple REF_NOT_FOUND errors. Hugo has become picker about directory references

### DIFF
--- a/workshop/content/_index.en.md
+++ b/workshop/content/_index.en.md
@@ -15,5 +15,5 @@ Start the [workshop here...]({{% relref "prereqs" %}})
 {{% /notice %}}
 
 {{% notice info %}}
-If you want to understand better the concepts that will be used [start here...]({{% relref intro.html %}})
+If you want to understand better the concepts that will be used [start here...]({{% relref intro %}})
 {{% /notice %}}

--- a/workshop/content/labs/advanced/aurora-global-database/_index.en.md
+++ b/workshop/content/labs/advanced/aurora-global-database/_index.en.md
@@ -12,7 +12,7 @@ awsServices:
 
 ### Objective
 
-These exercises will show you the steps for using the Global Database engine for Amazon Aurora for MySQL databases. If you want more information [click here]({{< ref "/services/databases/aurora/" >}} "Amazon Aurora").
+These exercises will show you the steps for using the Global Database engine for Amazon Aurora for MySQL databases. If you want more information [click here]({{< ref "/services/databases/aurora" >}} "Amazon Aurora").
 
 **By the end of this exercise, you will be able to:**
 

--- a/workshop/content/labs/advanced/aurora-global-database/_index.pt.md
+++ b/workshop/content/labs/advanced/aurora-global-database/_index.pt.md
@@ -12,7 +12,7 @@ awsServices:
 
 ### Objetivo
 
-Esses exercícios irão mostrar os passos para o uso do mecanismo Global Database para bases de dados do Amazon Aurora for MySQL. Caso queira mais informações [clique aqui]({{< ref "/services/databases/aurora/" >}} "Amazon Aurora").
+Esses exercícios irão mostrar os passos para o uso do mecanismo Global Database para bases de dados do Amazon Aurora for MySQL. Caso queira mais informações [clique aqui]({{< ref "/services/databases/aurora" >}} "Amazon Aurora").
 
 **Ao final desse exercício, você será capaz de:**
 - Criar clusters de banco de dados

--- a/workshop/content/labs/basics/lambda/_index.en.md
+++ b/workshop/content/labs/basics/lambda/_index.en.md
@@ -12,7 +12,7 @@ awsServices:
 
 ### Objective
 
-This exercise will show you the steps for exporting and importing Lambda functions between regions manually. If you want more information [click here]({{< ref "/services/compute/lambda/" >}} "AWS Lambda").
+This exercise will show you the steps for exporting and importing Lambda functions between regions manually. If you want more information [click here]({{< ref "/services/compute/lambda" >}} "AWS Lambda").
 
 **Required knowledge:**
 

--- a/workshop/content/labs/basics/lambda/_index.pt.md
+++ b/workshop/content/labs/basics/lambda/_index.pt.md
@@ -12,7 +12,7 @@ awsServices:
 
 ### Objetivo
 
-Esse exercício irá mostrar os passos para exportar e importar funções Lambda entre regiões manualmente. Caso queira mais informações [clique aqui]({{< ref "/services/compute/lambda/" >}} "AWS Lambda").
+Esse exercício irá mostrar os passos para exportar e importar funções Lambda entre regiões manualmente. Caso queira mais informações [clique aqui]({{< ref "/services/compute/lambda" >}} "AWS Lambda").
 
 **Conhecimentos necessários:** 
 - Uso básico do AWS CLI


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Prior to these changes, when I would try `hugo server` I would get these errors

```
Building sites … WARN 2021/08/12 17:40:44 Page.Dir is deprecated and will be removed in a future release. Use .File.Dir
ERROR 2021/08/12 17:40:44 [en] REF_NOT_FOUND: Ref "intro.html" from page "_index.en.md": page not found
ERROR 2021/08/12 17:40:44 [en] REF_NOT_FOUND: Ref "/services/databases/aurora/" from page "labs/advanced/aurora-global-database/_index.en.md": page not found
ERROR 2021/08/12 17:40:44 [en] REF_NOT_FOUND: Ref "/services/compute/lambda/" from page "labs/basics/lambda/_index.en.md": page not found
ERROR 2021/08/12 17:40:44 [pt] REF_NOT_FOUND: Ref "/services/databases/aurora/" from page "labs/advanced/aurora-global-database/_index.pt.md": page not found
ERROR 2021/08/12 17:40:44 [pt] REF_NOT_FOUND: Ref "/services/compute/lambda/" from page "labs/basics/lambda/_index.pt.md": page not found
Built in 1103 ms
Error: Error building site: logged 5 error(s)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
