### PR TITLE
Revision on Route53 Failover Policy in Private Hosted Zone Lab and on README.MD for HUGO info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Visit the workshop on this URL: [disaster-recovery.workshop.aws](https://disaste
 ## Developer Guide
 
 This workshop is built with markdown as a static HTML site using [hugo](http://gohugo.io).
+Warning: Make sure to use Hugo version prior to 0.93 where Page.Dir method has been deprecated according to [#4117](https://github.com/gohugoio/hugo/issues/4117).
 
 ```bash
 brew install hugo
@@ -28,6 +29,7 @@ Clone this repository and submodules:
 
 ```bash
 git clone https://github.com/aws-samples/disaster-recovery-workshop.git
+cd disaster-recovery-workshop/workshop
 git submodule init
 git submodule update
 ```
@@ -37,7 +39,6 @@ You'll find the content of the workshop in the [workshop/](workshop/) directory.
 You can start up a local development server by running:
 
 ```bash
-cd workshop
 # parameter -D (--buildDrafts) shows content marked as draft
 hugo server -D
 ```

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Visit the workshop on this URL: [disaster-recovery.workshop.aws](https://disaste
 
 This workshop is built with markdown as a static HTML site using [hugo](http://gohugo.io).
 
-Warning: Make sure to use Hugo version prior to 0.93 where Page.Dir method has been deprecated according to [#4117](https://github.com/gohugoio/hugo/issues/4117).
-
 ```bash
 brew install hugo
 ```

--- a/README.pt.md
+++ b/README.pt.md
@@ -19,6 +19,7 @@ Visite o workshop sobre este URL: [disaster-recovery.workshop.aws](https://disas
 ## Guia do desenvolvedor
 
 Este workshop é construído usando markdown como um site HTML estático usando [hugo](http://gohugo.io).
+Atenção: Utilize uma versão do Hugo inferior a 0.93 onde o método Page.Dir foi descontinuado de acordo com [#4117](https://github.com/gohugoio/hugo/issues/4117).
 
 ```bash
 brew install hugo
@@ -28,6 +29,7 @@ Clone esse repositório e os submódulos:
 
 ```bash
 git clone https://github.com/aws-samples/disaster-recovery-workshop.git
+cd disaster-recovery-workshop/workshop
 git submodule init
 git submodule update
 ```
@@ -37,7 +39,6 @@ Você encontrará o conteúdo da oficina no [workshop/](workshop/) diretório.
 Você pode iniciar um servidor de desenvolvimento local executando:
 
 ```bash
-cd workshop
 # parameter -D (--buildDrafts) shows content marked as draft
 hugo server -D
 ```

--- a/README.pt.md
+++ b/README.pt.md
@@ -20,8 +20,6 @@ Visite o workshop sobre este URL: [disaster-recovery.workshop.aws](https://disas
 
 Este workshop é construído usando markdown como um site HTML estático usando [hugo](http://gohugo.io).
 
-Atenção: Utilize uma versão do Hugo anterior a 0.93 onde o método Page.Dir foi descontinuado de acordo com [#4117](https://github.com/gohugoio/hugo/issues/4117).
-
 ```bash
 brew install hugo
 ```

--- a/workshop/content/labs/basics/route53/_index.en.md
+++ b/workshop/content/labs/basics/route53/_index.en.md
@@ -14,6 +14,8 @@ awsServices:
 
 This exercise will show you the steps for you to quickly configure DNS-based failover functionality for existing endpoints in different regions.
 
+Warning: For this lab you should use regions US-EAST-1 and US-WEST-1. If you are running an AWS event, please confirm this information with your instructor.
+
 **Required knowledge:**
 
 *   Basic Use of the AWS CLI

--- a/workshop/content/labs/basics/route53/_index.pt.md
+++ b/workshop/content/labs/basics/route53/_index.pt.md
@@ -15,6 +15,8 @@ draft: true
 
 Esse exercício irá mostrar os passos para você configurar rapidamente a funcionalidade de failover baseado em DNS para endpoints existentes em diferentes regiões. 
 
+Aviso: para este laboratório, você deve usar as regiões US-EAST-1 e US-WEST-1. Se você estiver executando um evento da AWS, confirme essas informações com seu instrutor.
+
 **Conhecimentos necessários:** 
 - Uso básico do AWS CLI
 - Conceitos básicos sobre balanceadores de carga

--- a/workshop/content/labs/basics/route53/cloudshell.en.md
+++ b/workshop/content/labs/basics/route53/cloudshell.en.md
@@ -15,6 +15,10 @@ hidden: true
 
 1. Create a EC2 **Key Pair** for access the EC2 instance in each region.
 
+   {{% notice info %}}
+   *For lab purposes you will be instructed to access the EC2 instances through SSH. That should keep it simple. Consider using Session Manager within AWS Systems Manager whenever possible as a security best practice.*
+   {{% /notice %}}
+
    ```bash
    aws ec2 create-key-pair --key-name us-east-1-keypair --query 'KeyMaterial' --output text > us-east-1-keypair.pem --region us-east-1
    aws ec2 create-key-pair --key-name us-west-1-keypair --query 'KeyMaterial' --output text > us-west-1-keypair.pem --region us-west-1

--- a/workshop/content/labs/basics/route53/cloudshell.en.md
+++ b/workshop/content/labs/basics/route53/cloudshell.en.md
@@ -351,7 +351,7 @@ hidden: true
     ```
 
    {{% notice info %}}
-   *After 1 minute, the Health Check will mark the **PRIMARY WEB SERVER** as **UNHEALTHY** and will trigger the failover mechanism.*
+   *After 2 minutes, the Health Check will mark the **PRIMARY WEB SERVER** as **UNHEALTHY** and will trigger the failover mechanism.*
    {{% /notice %}}
 
 

--- a/workshop/layouts/shortcodes/tabs.html
+++ b/workshop/layouts/shortcodes/tabs.html
@@ -27,7 +27,7 @@
 				{{ end }}
 			{{ end }}
 		{{ else}}
-		{{ $path := path.Join $.Page.Dir .include }}
+		{{ $path := path.Join $.Page.File.Dir .include }}
 		{{ $page := $.Page.Site.GetPage "page" $path }}
 		{{ with $page }}
 			{{ .Content }}


### PR DESCRIPTION
*Description of changes:*

On Route53 Failover Policy in Private Hosted Zone Lab:
[Fixed method from Page.Dir to Page.File.Dir in order to work with version v.0.93 and later)
[Added warning into Step 1 regarding EC2 access through SSH]
[Changed notice info from 1 to 2 minutes due to HC policy 3x 30s]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
